### PR TITLE
Country tlds

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,15 @@
+var lookup = require('country-code-lookup');
+
 module.exports = function (str) {
 	return new DomainName(str);
 };
 
 function DomainName(str) {
 	this.tokenized = (str || "").split(/\./gi).reverse();
+  if (lookup.byInternet((this.tokenized[0] || '').toUpperCase())) {
+    var country = this.tokenized.shift();
+    this.tokenized[0] = [this.tokenized[0], country].join('.');
+  }
 }
 
 DomainName.prototype = {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.5",
   "description": "Parse domain name into tld, sld, domain, domainName, host",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "country-code-lookup": "0.0.2"
+  },
   "devDependencies": {
     "tape": "~2.1.0"
   },

--- a/test.js
+++ b/test.js
@@ -13,3 +13,14 @@ test('basic test', function (t) {
 	t.equal(d.level(), 4);
 	t.end();
 });
+test('country-tlds', function(t) {
+  var d = parse('stoner.steve.weedcopter.co.uk');
+  t.equal(d.tld, 'co.uk');
+	t.equal(d.sld, 'weedcopter');
+	t.equal(d.domain, 'steve.weedcopter.co.uk');
+	t.equal(d.domainName, 'weedcopter.co.uk');
+	t.equal(d.host, 'stoner');
+	t.equal(d.level(3), 'steve');
+	t.equal(d.level(), 4);
+	t.end();
+});

--- a/test.js
+++ b/test.js
@@ -16,11 +16,16 @@ test('basic test', function (t) {
 test('country-tlds', function(t) {
   var d = parse('stoner.steve.weedcopter.co.uk');
   t.equal(d.tld, 'co.uk');
-	t.equal(d.sld, 'weedcopter');
-	t.equal(d.domain, 'steve.weedcopter.co.uk');
-	t.equal(d.domainName, 'weedcopter.co.uk');
-	t.equal(d.host, 'stoner');
-	t.equal(d.level(3), 'steve');
-	t.equal(d.level(), 4);
-	t.end();
+  t.equal(d.sld, 'weedcopter');
+  t.equal(d.domain, 'steve.weedcopter.co.uk');
+  t.equal(d.domainName, 'weedcopter.co.uk');
+  t.equal(d.host, 'stoner');
+  t.equal(d.level(3), 'steve');
+  t.equal(d.level(), 4);
+  t.end();
+});
+test('no error on country', function(t) {
+  var d = parse(undefined);
+  t.equal(d.tld, null);
+  t.end(); // it didn't error :)
 });


### PR DESCRIPTION
@wankdanker this aims to close: https://github.com/wankdanker/node-domain-name-parser/issues/1 -- we ran into on production over here.

i took at a look at [countries-list](https://www.npmjs.com/package/country-code-lookup) but it didn't have `uk` for great britain -- only `GB`, at least by my quick check.

i ended up using [country-code-lookup](https://www.npmjs.com/package/country-code-lookup) for that reason. no real other thought given.

what do you think? let me know!
