### PR TITLE
ensures that .co urls parse properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ module.exports = function (str) {
 
 function DomainName(str) {
 	this.tokenized = (str || "").split(/\./gi).reverse();
-	if (countries[(this.tokenized[0] || '').toUpperCase()]) {
+  var first = (this.tokenized[0] || '').toUpperCase();
+	if (first != 'CO' && countries[first]) {
 		var country = this.tokenized.shift();
 		this.tokenized[0] = [this.tokenized[0], country].join('.');
 	}

--- a/test.js
+++ b/test.js
@@ -24,6 +24,17 @@ test('country-tlds', function(t) {
   t.equal(d.level(), 4);
   t.end();
 });
+test('.co url', function(t) {
+  var d = parse('stoner.steve.weedcopter.co');
+  t.equal(d.tld, 'co');
+  t.equal(d.sld, 'weedcopter');
+  t.equal(d.domain, 'steve.weedcopter.co');
+  t.equal(d.domainName, 'weedcopter.co');
+  t.equal(d.host, 'stoner');
+  t.equal(d.level(3), 'steve');
+  t.equal(d.level(), 4);
+  t.end();
+});
 test('no error on country', function(t) {
   var d = parse(undefined);
   t.equal(d.tld, null);


### PR DESCRIPTION
hey @wankdanker, how's things?

noticed that `foo.co` returned the wrong results with the country stuff i helped you with. my bad.

note: after / if this lands, there's still another outlier to update (happy to do so). i noticed that `com.co` (for testing that we didn't ignore colombian domains!) doesn't work -- that diff got a little bit bigger, so easier to get our heads around one at a time.

we're blocked in production on this, so i'll put the fix in on our codebase until you've had a chance to review.

looking forward to your feedback!
